### PR TITLE
Allow Inherit Only propagation for WRITE_PROPERTIES ACE

### DIFF
--- a/src/main/java/net/tirasa/adsddl/ntsd/dacl/DomainJoinRoleAssertion.java
+++ b/src/main/java/net/tirasa/adsddl/ntsd/dacl/DomainJoinRoleAssertion.java
@@ -86,7 +86,7 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             null,
             null,
             AceFlag.CONTAINER_INHERIT_ACE,
-            AceFlag.INHERIT_ONLY_ACE);
+            null);
 
     protected static final AceAssertion READ_PERMISSIONS = new AceAssertion(
             AceRights.parseValue(0x00020000),


### PR DESCRIPTION
Current WRITE_PROPERTIES assertion is only allowing domain join account with "Write All Properties"(WP) permission entry applied to "This object and all descendant objects" of OU.  This change aims to allow account with WP permission set only for "All descendant objects". 
