### PR TITLE
Changes:

### DIFF
--- a/src/main/java/net/tirasa/adsddl/ntsd/dacl/AceAssertion.java
+++ b/src/main/java/net/tirasa/adsddl/ntsd/dacl/AceAssertion.java
@@ -38,33 +38,44 @@ public class AceAssertion {
     /**
      * A single AceRight.
      */
-    private final AceRights aceRight;
+    private AceRights aceRight;
 
     /**
      * One or more AceObjectFlags. May be null.
      */
-    private final AceObjectFlags aceObjectFlags;
+    private AceObjectFlags aceObjectFlags;
 
     /**
      * Object type GUID. Must be set if {@code Flag.ACE_OBJECT_TYPE_PRESENT} is one of the AceObjectFlags; otherwise null.
      */
-    private final String objectType;
+    private String objectType;
 
     /**
      * Inherited Object type GUID. Must be set if {@code Flag.ACE_INHERITED_OBJECT_TYPE_PRESENT} is one of the AceObjectFlags;
      * otherwise null.
      */
-    private final String inheritedObjectType;
+    private String inheritedObjectType;
 
     /**
      * Single AceFlag that stipulates an ACE must contain it; may be null.
      */
-    private final AceFlag requiredFlag;
+    private AceFlag requiredFlag;
 
     /**
      * Single AceFlag that stipulates an ACE must NOT contain it; may be null.
      */
-    private final AceFlag excludedFlag;
+    private AceFlag excludedFlag;
+
+    /**
+     * AceAssertion constructor
+     *
+     * @param aceRight
+     *            A single AceRight (e.g.: use {@code AceRights.parseValue(0x00000004)} if {@code AceRights.ObjectRight} enum does
+     *            not contain desired right.) MUST be specified.
+     */
+    public AceAssertion(AceRights aceRight) {
+        this.aceRight = aceRight;
+    }
 
     /**
      * AceAssertion constructor

--- a/src/main/java/net/tirasa/adsddl/ntsd/dacl/DACLAssertor.java
+++ b/src/main/java/net/tirasa/adsddl/ntsd/dacl/DACLAssertor.java
@@ -594,7 +594,7 @@ public class DACLAssertor {
                 res = false;
             }
         } else if (aceFlags != null && !aceFlags.isEmpty()) {
-            res = false;
+            LOG.debug("doRequiredFlagsMatch, found aceFlags : {}, but not looking for any required flags", aceFlags);
         }
         LOG.debug("doRequiredFlagsMatch, result: {}", res);
         return res;

--- a/src/main/java/net/tirasa/adsddl/ntsd/dacl/DomainJoinRoleAssertion.java
+++ b/src/main/java/net/tirasa/adsddl/ntsd/dacl/DomainJoinRoleAssertion.java
@@ -21,14 +21,14 @@
  */
 package net.tirasa.adsddl.ntsd.dacl;
 
-import java.util.Arrays;
-import java.util.List;
-
 import net.tirasa.adsddl.ntsd.SID;
 import net.tirasa.adsddl.ntsd.data.AceFlag;
 import net.tirasa.adsddl.ntsd.data.AceObjectFlags;
 import net.tirasa.adsddl.ntsd.data.AceObjectFlags.Flag;
 import net.tirasa.adsddl.ntsd.data.AceRights;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Represents an {@linkplain AdRoleAssertion} which specifies the criteria required to join or remove computers
@@ -48,6 +48,9 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
      */
     protected static final String RESET_PASSWORD_CR_GUID = "00299570-246d-11d0-a768-00aa006e0529";
 
+    /**
+     * Create computer object applied to "This object and all descendant objects"
+     */
     protected static final AceAssertion CREATE_COMPUTER = new AceAssertion(
             AceRights.parseValue(0x00000001),
             new AceObjectFlags(Flag.ACE_OBJECT_TYPE_PRESENT),
@@ -56,6 +59,9 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             AceFlag.INHERIT_ONLY_ACE);
 
+    /**
+     * DELETE_COMPUTER - Delete computer object applied to "This object and all descendant objects"
+     */
     protected static final AceAssertion DELETE_COMPUTER = new AceAssertion(
             AceRights.parseValue(0x00000002),
             new AceObjectFlags(Flag.ACE_OBJECT_TYPE_PRESENT),
@@ -64,6 +70,9 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             AceFlag.INHERIT_ONLY_ACE);
 
+    /**
+     * LIST_CONTENTS - List contents applied to "This object and all descendant objects"
+     */
     protected static final AceAssertion LIST_CONTENTS = new AceAssertion(
             AceRights.parseValue(0x00000004),
             null,
@@ -72,6 +81,20 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             AceFlag.INHERIT_ONLY_ACE);
 
+
+
+    /**
+     * READ_PROPERTIES - Read All Properties applied at any of below scopes on target Organizational Unit
+     * - This object only
+     * - This object and all descendant objects
+     * - All descendant objects
+     */
+    protected static final AceAssertion READ_PROPERTIES_ANY_SCOPE = new AceAssertion(
+            AceRights.parseValue(0x00000010));
+
+    /**
+     * READ_PROPERTIES - Read All Properties applied to "This object and all descendant objects"
+     */
     protected static final AceAssertion READ_PROPERTIES = new AceAssertion(
             AceRights.parseValue(0x00000010),
             null,
@@ -80,6 +103,20 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             AceFlag.INHERIT_ONLY_ACE);
 
+    /**
+     *  WRITE_PROPERTIES_COMPUTER_OBJECTS - Write all propeties applied to "Descendant Computer Objects"
+     */
+    protected static final AceAssertion WRITE_PROPERTIES_COMPUTER_OBJECTS = new AceAssertion(
+            AceRights.parseValue(0x00000020),
+            null,
+            null,
+            COMPUTER_SCHEMA_ID_GUID,
+            AceFlag.CONTAINER_INHERIT_ACE,
+            null);
+
+    /**
+     *  WRITE_PROPERTIES - Write all propeties applied to "This object and all descendant objects"
+     */
     protected static final AceAssertion WRITE_PROPERTIES = new AceAssertion(
             AceRights.parseValue(0x00000020),
             null,
@@ -88,6 +125,9 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             AceFlag.INHERIT_ONLY_ACE);
 
+    /**
+     * READ_PERMISSIONS -  Read Permissions(a.k.a Read Control) applied to "This object and all descendant objects"
+     */
     protected static final AceAssertion READ_PERMISSIONS = new AceAssertion(
             AceRights.parseValue(0x00020000),
             null,
@@ -96,6 +136,9 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             AceFlag.INHERIT_ONLY_ACE);
 
+    /**
+     * RESET_PASSWORD  - Permission to force reset password applied to  "Descendant Computer Objects"
+     */
     protected static final AceAssertion RESET_PASSWORD = new AceAssertion(
             AceRights.parseValue(AceRights.ObjectRight.CR.getValue()),
             new AceObjectFlags(Flag.ACE_OBJECT_TYPE_PRESENT, Flag.ACE_INHERITED_OBJECT_TYPE_PRESENT),
@@ -104,14 +147,43 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
             AceFlag.CONTAINER_INHERIT_ACE,
             null);
 
-    protected static final AceAssertion[] DOMAIN_JOIN_ASSERTIONS = {
-        CREATE_COMPUTER,
-        DELETE_COMPUTER,
-        LIST_CONTENTS,
-        READ_PROPERTIES,
-        WRITE_PROPERTIES,
-        READ_PERMISSIONS,
-        RESET_PASSWORD };
+
+    protected static List<AceAssertion> domainJoinAssertions(boolean withMinimumRequiredPermissions) {
+
+        if (withMinimumRequiredPermissions) {
+            return Arrays.asList(
+                    CREATE_COMPUTER,
+                    DELETE_COMPUTER,
+                    READ_PROPERTIES_ANY_SCOPE,
+                    WRITE_PROPERTIES_COMPUTER_OBJECTS,
+                    RESET_PASSWORD);
+        }
+
+        return Arrays.asList(CREATE_COMPUTER,
+                DELETE_COMPUTER,
+                LIST_CONTENTS,
+                READ_PROPERTIES,
+                WRITE_PROPERTIES,
+                READ_PERMISSIONS,
+                RESET_PASSWORD);
+    }
+
+    /**
+     * DomainJoinRoleAssertion constructor
+     *
+     * @param principal
+     * SID of the user or group
+     * @param isGroup
+     * whether the principal is a group
+     * @param tokenGroups
+     * list of token group SIDs which should be searched if the principal itself does not meet all the
+     * criteria (when the principal is a user). May be null.
+     * @param withMinimumRequiredPermissions
+     * assert with minimum required join account permissions
+     */
+    public DomainJoinRoleAssertion(SID principal, boolean isGroup, List<SID> tokenGroups, boolean withMinimumRequiredPermissions) {
+        super(domainJoinAssertions(withMinimumRequiredPermissions), principal, isGroup, tokenGroups);
+    }
 
     /**
      * DomainJoinRoleAssertion constructor
@@ -125,6 +197,6 @@ public class DomainJoinRoleAssertion extends AdRoleAssertion {
      * criteria (when the principal is a user). May be null.
      */
     public DomainJoinRoleAssertion(SID principal, boolean isGroup, List<SID> tokenGroups) {
-        super(Arrays.asList(DOMAIN_JOIN_ASSERTIONS), principal, isGroup, tokenGroups);
+        this(principal,isGroup,tokenGroups,false);
     }
 }


### PR DESCRIPTION
-Support for validating join accounts with minimum required permissions to add a workstation to domain.

   CREATE_COMPUTER - Create computer object applied to "This object and all descendant objects" 
   DELETE_COMPUTER - Delete computer object applied to "This object and all descendant objects"
   READ_PROPERTIES_ANY_SCOPE - Read All Properties applied at any scope on target OU
   WRITE_PROPERTIES_COMPUTER_OBJECTS - Write all properties applied to "Descendant Computer Objects"
   RESET_PASSWORD  - Permission to force reset password applied to  "Descendant Computer Objects"
    

-Fix for DACLAssertor.doRequiredFlagsMatch, that is failing when account has ACE flags despite the fact that assertion is not looking for any required flags.